### PR TITLE
[programmers_150369] 택배 배달과 수거하기

### DIFF
--- a/5week/Yoojkim/programmers_150369.java
+++ b/5week/Yoojkim/programmers_150369.java
@@ -1,0 +1,77 @@
+import java.util.*;
+
+class Node implements Comparable<Node>{
+    int dist;
+    int weight;
+    
+    public Node(int dist, int weight){
+        this.dist = dist;
+        this.weight = weight;
+    }
+    
+    public int compareTo(Node n){
+        return n.dist - this.dist;
+    }
+}
+
+class Solution {
+    PriorityQueue<Node> deliver = new PriorityQueue<>();
+    PriorityQueue<Node> retrieve = new PriorityQueue<>();
+    
+    public long solution(int cap, int n, int[] deliveries, int[] pickups) {
+        for(int i=0;i<n;i++){
+            
+            if(deliveries[i] != 0){
+                deliver.add(new Node(i+1, deliveries[i]));
+            }
+            
+            if(pickups[i] != 0){
+                retrieve.add(new Node(i+1, pickups[i]));
+            }
+        }
+        
+        long allDist = 0;
+        while(!deliver.isEmpty() || !retrieve.isEmpty()){
+            allDist += getMaxDist() * 2;
+                
+            calDist(cap, deliver);
+            calDist(cap, retrieve);
+        }
+        
+        return allDist;
+    }
+    
+    private void calDist(int cap, PriorityQueue<Node> queue){
+        int nowCap=0;
+        
+        while(!queue.isEmpty()){
+            Node newNode = queue.poll();
+            
+            if(newNode.weight+nowCap <= cap){
+                nowCap += newNode.weight;
+                
+                continue;
+            } 
+            
+            int possibleCap = cap - nowCap;
+            nowCap += possibleCap;
+            
+            queue.add(new Node(newNode.dist, newNode.weight - possibleCap));
+            break;
+        }
+    }
+    
+    private int getMaxDist(){
+        int deliverMax = 0; int retrieveMax = 0;
+        
+        if(!deliver.isEmpty()){
+            deliverMax = deliver.peek().dist;
+        }
+        
+        if(!retrieve.isEmpty()){
+            retrieveMax = retrieve.peek().dist;
+        }
+        
+        return deliverMax>retrieveMax?deliverMax:retrieveMax;
+    }
+}


### PR DESCRIPTION
## 사용 알고리즘 
- Greedy
- 자료구조(우선순위 큐)

## 간단 문제풀이
배달 큐와 수거 큐를 각각 구현하고 거리 순으로 자동 정렬한다.
한 turn당 배달과 수거를 할 수 있으니, turn에 배달 큐와 수거 큐 중 큰 거리를 배정한다. 
turn마다 capacity에 따라 큐를 최신화한다.

큐가 다 빌 때 까지를 이를 반복하면 탐욕법을 통해 최소 거리를 계산할 수 있다.

## 비고
간단한 문제였는데 반복문 조건 중 ||을 &&로 써서 거의 15분 동안 애를 먹었다.
ㅠㅠ 신중하게 작성하는 것이 좋겠다. 

## 문제 링크 
https://school.programmers.co.kr/learn/courses/30/lessons/150369
