### PR TITLE
programmers_43162 - levocation 20240226

### DIFF
--- a/6week/levocation/20240226/programmers_43162.java
+++ b/6week/levocation/20240226/programmers_43162.java
@@ -1,0 +1,33 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int n, int[][] computers) {
+        int answer = 0;
+        
+        Queue<Integer> q = new LinkedList<>();
+        int cur;
+        
+        int len = computers.length;
+        
+        for (int i = 0; i < len; i++) {
+            if (computers[i][i] == 1) { // computers[i][i]는 초기에 항상 1로 시작하지만, 이미 탐색한 경우에는 -1이다.
+                q.add(i);
+
+                while (!q.isEmpty()) {
+                    cur = q.poll();
+                    if (computers[cur][cur] == -1) continue; // 이미 탐색한 컴퓨터는 두 번 탐색할 필요 없음
+                    for (int nxt = 0; nxt < len; nxt++) {
+                        if (computers[cur][nxt] == 1) {
+                            computers[cur][nxt] = -1;
+                            computers[nxt][cur] = -1;
+                            q.add(nxt);
+                        }
+                    }
+                }
+                answer++;
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
## 사용 알고리즘 

그래프
너비 우선 탐색
큐

## 간단 문제풀이

computers 배열이 0과 1로 된 값이고, 간선이 연결된 경우 1로 표기하므로
따로 배열을 만들지 않고 computers에서 방문 여부를 표시한다.

- 네트워크가 없는 경우 : 0
- 네트워크가 있으나, 아직 확인하지 않은 경우 : 1
- 네트워크가 있으나, 이미 확인한 경우 : -1

computers[i][i]가 항상 1이라는 것을 이용해서
computers[i][i]의 값이 1일 경우, 해당 컴퓨터로부터 탐색을 시작한다.

탐색을 할 때 한 번도 확인하지 않았지만 네트워크가 연결되어있는 컴퓨터의 경우
경로를 확인했다는 의미로 해당 경로를 -1로 표시한다.
(간선에 방향이 없으므로 양방향 모두 -1로 표시)

탐색을 진행할 때 해당 컴퓨터를 이미 탐색한 적이 있다면, 해당 컴퓨터에 대해서는 탐색을 할 필요가 없다.
이는 computers[i][i]의 값이 -1일 때와 같다.

## 비고

초기 컴퓨터의 위치를 지정할 때, 배열에서 모든 위치를 보는 것이 아닌
[i][i]의 위치만을 보는 것으로 실행 시간을 줄일 수 있었다.

## 문제 링크 

https://school.programmers.co.kr/learn/courses/30/lessons/43162